### PR TITLE
feat: use clap to parse args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +162,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,6 +276,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +323,12 @@ dependencies = [
  "number_prefix",
  "regex",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
@@ -427,6 +534,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "bytes",
+ "clap",
  "env_logger",
  "indicatif",
  "log",
@@ -526,6 +634,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -649,6 +763,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ indicatif = "0.15.0"
 regex = "1"
 redis = "0.21.4"
 log = "0.4"
+clap = { version = "4.5.13", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <a href="https://github.com/sleeprite/rudis"><img src="https://img.shields.io/github/stars/sleeprite/rudis?style=flat-square&logo=GitHub"></a>
 <a href="https://github.com/sleeprite/rudis/blob/master/LICENSE"><img src="https://img.shields.io/github/license/sleeprite/rudis.svg?style=flat-square"></a>
 
-<h4>高 性 能 内 存 数 据 库 </h4> 
+<h4>高 性 能 内 存 数 据 库 </h4>
 
 **[🔶 Explore the docs »](https://sleeprite.github.io/rudis)**
 
@@ -38,11 +38,11 @@ Rudis 是一个采用 Rust 语言编写得高性能键值存储系统，旨在�
    ( ==  ^  == )
     )         (          Bind: 127.0.0.1:6379
    (           )
-  ( (  )   (  ) )        
+  ( (  )   (  ) )
  (__(__)___(__)__)
-    
+
 [2024-04-30T02:00:55Z INFO  rudis_server] Start loading appendfile
-[=======================================] percent: 100% lines: 6/6 
+[=======================================] percent: 100% lines: 6/6
 [2024-04-30T02:00:55Z INFO  rudis_server] Server initialized
 [2024-04-30T02:00:55Z INFO  rudis_server] Ready to accept connections
 ```
@@ -55,16 +55,17 @@ cargo run
 
 // 带参启动
 cargo run -- --port 8848
+cargo run -- --save 20/1 60/2
 
 // 指定配置
-cargo run -- rudis.properties
+cargo run -- --config rudis.properties
 
 // 构建程序
 cargo build
 
 cargo build --release --target=x86_64-unknown-linux-musl
 
-cargo build --release 
+cargo build --release
 
 // 代码检测
 cargo clippy
@@ -213,7 +214,7 @@ OK
 
 ## 命令列表
 
-| Command | Supprt | Appendfile | Test case | Document | 
+| Command | Supprt | Appendfile | Test case | Document |
 | ------- | ------ | ---------- | --------- |--------- |
 | set     | ✅    | ✅         | ✅       | ✅       |
 | get     | ✅    | ⚪         | ✅       | ✅       |

--- a/src/db/db_config.rs
+++ b/src/db/db_config.rs
@@ -1,13 +1,12 @@
-use std::{env, fs, path::PathBuf};
+use std::fs;
 
 /*
  * Redis 配置
- * 
  * @param bind 地址
  * @param port 端口
  * @param password 密码
  * @param maxclients 客户端上限
- * @param databases 初始化数据库 
+ * @param databases 初始化数据库
  * @param appendfilename 命令持久化文件
  * @param appendonly 是否开启持久化
  */
@@ -23,298 +22,129 @@ pub struct RedisConfig {
     pub appendfsync: Option<String>,
     pub maxclients: usize,
     pub save: Option<String>,
-    pub dir: String
+    pub dir: String,
 }
 // dbfilename dump.rdb
 
-
-impl Default for RedisConfig {
-    fn default() -> Self {
-
-        let filename = "appendonly.aof";
-        let mut port = get_port_or(6379);
-        let mut bind = get_bind_or(String::from("127.0.0.1"));
-        let mut databases = get_databases_or(16);
-        let mut dbfilename = get_dbfilename_or(Some("dump.rdb".to_string()));
-        let mut password = get_password_or(None);
-        let mut appendonly = get_appendonly_or(false);
-        let mut appendfilename = get_appendfilename_or(Some(filename.to_string()));
-        let mut hz = get_hz_or(10);
-        let mut maxclients = get_maxclients_or(0);
-        let mut appendfsync = get_appendfsync_or(None);
-        let mut save = get_save_or(None);
-        let mut dir = get_dir_or("./".to_string());
-        let config_path = get_config_path_or(None);
-        
-        if let Some(config) = config_path {
+impl From<crate::tools::cli::Cli> for RedisConfig {
+    fn from(value: crate::tools::cli::Cli) -> Self {
+        let mut redis_config = RedisConfig::default();
+        if let Some(config) = value.config {
             if let Ok(content) = fs::read_to_string(config) {
                 for line in content.lines() {
                     if let Some((key, value)) = parse_config_line(line) {
-                        print!("{}",key.as_str());
                         match key.as_str() {
-                            "dir" => dir = value.to_string(),
-                            "port" => port = value.parse().unwrap_or(port),
-                            "bind" => bind = value.to_string(),
-                            "password" => password = Some(value.to_string()),
-                            "dbfilename" => dbfilename = Some(value.to_string()),
-                            "databases" => databases = value.parse().unwrap_or(databases),
-                            "maxclients" => maxclients = value.parse().unwrap_or(maxclients),
-                            "appendonly" => appendonly = value.parse().unwrap_or(appendonly),
-                            "appendfilename" => appendfilename = Some(value.to_string()),
-                            "appendfsync" => appendfsync = Some(value.to_string()),
-                            "save" => save = Some(value.to_string()),
-                            "hz" => hz = value.parse().unwrap_or(hz),
-                            _ => {}  
+                            "dir" => redis_config.dir = value.to_string(),
+                            "port" => {
+                                redis_config.port = value.parse().unwrap_or(redis_config.port)
+                            }
+                            "bind" => redis_config.bind = value.to_string(),
+                            "password" => redis_config.password = Some(value.to_string()),
+                            "dbfilename" => redis_config.dbfilename = Some(value.to_string()),
+                            "databases" => {
+                                redis_config.databases =
+                                    value.parse().unwrap_or(redis_config.databases)
+                            }
+                            "maxclients" => {
+                                redis_config.maxclients =
+                                    value.parse().unwrap_or(redis_config.maxclients)
+                            }
+                            "appendonly" => {
+                                redis_config.appendonly =
+                                    value.parse().unwrap_or(redis_config.appendonly)
+                            }
+                            "appendfilename" => {
+                                redis_config.appendfilename = Some(value.to_string())
+                            }
+                            "appendfsync" => redis_config.appendfsync = Some(value.to_string()),
+                            "save" => redis_config.save = Some(value.to_string()),
+                            "hz" => redis_config.hz = value.parse().unwrap_or(redis_config.hz),
+                            _ => {}
                         }
                     }
                 }
-            } else {
-                eprintln!("Error reading the config file");
             }
         }
 
+        if let Some(bind) = value.bind {
+            redis_config.bind = bind;
+        }
+        if let Some(port) = value.port {
+            redis_config.port = port;
+        }
+        if let Some(password) = value.password {
+            redis_config.password = Some(password);
+        }
+        if let Some(databases) = value.databases {
+            redis_config.databases = databases;
+        }
+        if let Some(dbfilename) = value.dbfilename {
+            redis_config.dbfilename = Some(dbfilename);
+        }
+        if let Some(appendfilename) = value.appendfilename {
+            redis_config.appendfilename = Some(appendfilename);
+        }
+        if let Some(appendonly) = value.appendonly {
+            if appendonly == "true" {
+                redis_config.appendonly = true;
+            } else {
+                redis_config.appendonly = false;
+            }
+        }
+        if let Some(hz) = value.hz {
+            redis_config.hz = hz;
+        }
+        if let Some(appendfsync) = value.appendfsync {
+            redis_config.appendfsync = Some(appendfsync);
+        }
+        if let Some(maxclients) = value.maxclients {
+            redis_config.maxclients = maxclients;
+        }
+        if value.save.len() > 0 {
+            redis_config.save = Some(
+                value
+                    .save
+                    .iter()
+                    .map(|x| format!("{} {}", x.0, x.1))
+                    .collect::<Vec<String>>()
+                    .join(" "),
+            );
+        }
+        if let Some(dir) = value.dir {
+            redis_config.dir = dir.to_str().unwrap().to_string();
+        }
+        redis_config
+    }
+}
+
+impl Default for RedisConfig {
+    fn default() -> Self {
         Self {
-            port,
-            password,
-            appendfsync,
-            dbfilename,
-            databases,
-            appendfilename,
-            appendonly,
-            maxclients,
-            bind,
-            save,
-            dir,
-            hz
+            bind: "127.0.0.1".to_string(),
+            port: 6379,
+            password: None,
+            databases: 16,
+            dbfilename: Some("dump.rdb".to_string()),
+            appendfilename: Some("appendonly.aof".to_string()),
+            appendonly: false,
+            hz: 10,
+            appendfsync: None,
+            maxclients: 0,
+            save: None,
+            dir: "./".to_string(),
         }
     }
 }
 
 fn parse_config_line(line: &str) -> Option<(String, String)> {
+    let line = line.trim();
+    if line.starts_with('#') {
+        return None;
+    }
     let parts: Vec<&str> = line.splitn(2, '=').map(|s| s.trim()).collect();
     if parts.len() == 2 {
         Some((parts[0].to_string(), parts[1].to_string()))
     } else {
         None
     }
-}
-
-/*
- * 获取 port 参数
- *
- * @param default 默认值 false
- */
-fn get_appendonly_or(default: bool) -> bool {
-    let mut args = env::args().skip_while(|arg| arg != "--appendonly").take(2);
-    if args.next().is_none() {
-        return default;
-    }
-
-    if let Some(arg) = args.next() {
-        arg.parse().expect("'--appendonly' must have a value")
-    } else {
-        default
-    }
-}
-
-/*
- * 获取 port 参数
- *
- * @param default 默认端口（6379）
- */
-fn get_port_or(default: u16) -> u16 {
-    let mut args = env::args().skip_while(|arg| arg != "--port").take(2);
-    if args.next().is_none() {
-        return default;
-    }
-
-    if let Some(arg) = args.next() {
-        arg.parse().expect("'--port' must have a value")
-    } else {
-        default
-    }
-}
-
-fn get_hz_or(default: u64) -> u64 {
-    let mut args = env::args().skip_while(|arg| arg != "--hz").take(2);
-    if args.next().is_none() {
-        return default;
-    }
-
-    if let Some(arg) = args.next() {
-        arg.parse().expect("'--hz' must have a value")
-    } else {
-        default
-    }
-}
-
-/*
- * 获取 maxclients 参数
- *
- * @param default 默认值 1000
- */
-fn get_maxclients_or(default: usize) -> usize {
-    let mut args = env::args().skip_while(|arg| arg != "--maxclients").take(2);
-    if args.next().is_none() {
-        return default;
-    }
-
-    if let Some(arg) = args.next() {
-        arg.parse().expect("'--maxclients' must have a value")
-    } else {
-        default
-    }
-}
-
-/*
- * 获取 databases 参数
- *
- * @param default 默认数量（16）
- */
-fn get_databases_or(default: usize) -> usize {
-    let mut args = env::args().skip_while(|arg| arg != "--databases").take(2);
-    if args.next().is_none() {
-        return default;
-    }
-
-    if let Some(arg) = args.next() {
-        arg.parse().expect("'--databases' must have a value")
-    } else {
-        default
-    }
-}
-
-/*
- * 获取 password 参数
- *
- * @param default_password 默认密码（None）
- */
-fn get_password_or(default_password: Option<String>) -> Option<String> {
-    let mut args = env::args().skip_while(|arg| arg != "--password").take(2);
-    if args.next().is_none() {
-        return default_password;
-    }
-
-    if let Some(arg) = args.next() {
-        Some(arg)
-    } else {
-        default_password
-    }
-}
-
-/*
- * 获取 bind 参数
- *
- * @param default_bind 绑定主机（None）
- */
-fn get_bind_or(default_bind: String) -> String {
-    let mut args = env::args().skip_while(|arg| arg != "--bind").take(2);
-    if args.next().is_none() {
-        return default_bind;
-    }
-
-    if let Some(arg) = args.next() {
-        arg
-    } else {
-        default_bind
-    }
-}
-
-
-/*
- * 获取 dir 参数
- *
- * @param default_dir 绑定主机（None）
- */
-fn get_dir_or(default_dir: String) -> String {
-    let mut args = env::args().skip_while(|arg| arg != "--dir").take(2);
-    if args.next().is_none() {
-        return default_dir;
-    }
-
-    if let Some(arg) = args.next() {
-        arg
-    } else {
-        default_dir
-    }
-}
-
-/*
- * 获取 dbfilename 参数
- *
- * @param default_dbfilename RDB 文件名（None）
- */
-fn get_dbfilename_or(default_dbfilename: Option<String>) -> Option<String >{
-    let mut args = env::args().skip_while(|arg| arg != "--dbfilename").take(2);
-    if args.next().is_none() {
-        return default_dbfilename;
-    }
-
-    if let Some(arg) = args.next() {
-        Some(arg)
-    } else {
-        default_dbfilename
-    }
-}
-
-/*
- * 获取 save 参数
- *
- * @param default_save
- */
-fn get_save_or(default_save: Option<String>) -> Option<String> {
-    let mut args = env::args().skip_while(|arg| arg != "--save").take(3); // 获取三位
-    if args.next().is_none() {
-        return default_save;
-    }
-
-    if let (Some(i), Some(c)) = (args.next(), args.next()) {
-        Some(format!("{} {}", i, c))
-    } else {
-        default_save
-    }
-}
-
-
-/*
- * 获取 appendfilename 参数
- */
-fn get_appendfilename_or(default_appendfilename: Option<String>) -> Option<String> {
-    let mut args = env::args().skip_while(|arg| arg != "--appendfilename").take(2);
-    if args.next().is_none() {
-        return default_appendfilename;
-    }
-
-    if let Some(arg) = args.next() {
-        Some(arg)
-    } else {
-        default_appendfilename
-    }
-}
-
-/*
- * 获取 appendfsync 参数
- */
-fn get_appendfsync_or(default_appendfsync: Option<String>) -> Option<String> {
-    let mut args = env::args().skip_while(|arg| arg != "--appendfsync").take(2);
-    if args.next().is_none() {
-        return default_appendfsync;
-    }
-
-    if let Some(arg) = args.next() {
-        Some(arg)
-    } else {
-        default_appendfsync
-    }
-}
-
-fn get_config_path_or(default_config_path: Option<String>) -> Option<String> {
-    let mut args = env::args();
-    if let Some(config_path_arg) = args.nth(1) {
-        let config_path = PathBuf::from(&config_path_arg);
-        if config_path.is_file() {
-            return Some(config_path_arg)
-        } 
-    } 
-    default_config_path
 }

--- a/src/tools/cli.rs
+++ b/src/tools/cli.rs
@@ -1,0 +1,69 @@
+use clap::Parser;
+use std::error::Error;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[command(version,name="Rudis" ,about="Rudis, A high-performance in memory database", long_about = None)]
+pub struct Cli {
+    /// 指定Rudis服务器绑定的IP地址，可以是IP地址或主机名，127.0.0.1表示只接受来自本机的连接
+    #[arg(short, long)]
+    pub bind: Option<String>,
+
+    /// 指定Rudis服务器监听的TCP端口，客户端通过此端口与Rudis服务器进行通信
+    #[arg(short, long)]
+    pub port: Option<u16>,
+
+    /// 启用密码保护，以增强Rudis服务器的安全性，留空不启用密码保护
+    #[arg(long)]
+    pub password: Option<String>,
+
+    /// 定义Rudis实例中可用的数据库数量，Rudis默认支持16个独立的数据库
+    #[arg(long)]
+    pub databases: Option<usize>,
+
+    /// 设置Rudis可以同时处理的最大客户端连接数
+    #[arg(long)]
+    pub maxclients: Option<usize>,
+
+    /// 设置Rudis进行过期键检测的频率，单位为秒，M 表示每秒钟进行M次过期键的检测
+    #[arg(long)]
+    pub hz: Option<u64>,
+
+    /// 数据持久化目录
+    #[arg(long, value_hint = clap::ValueHint::DirPath)]
+    pub dir: Option<PathBuf>,
+
+    /// 定义RDB（Rudis Database）快照文件的名称，该文件用于数据的持久化存储
+    #[arg(long)]
+    pub dbfilename: Option<String>,
+
+    /// 定义RDB快照的自动保存条件，格式为 M/N ，表示每M秒如果至少有N个键被改变，则会进行一次快照保存，eg: 60/1 10/1
+    #[arg(long, value_parser = parse_rdb_save)]
+    pub save: Vec<(u64, u64)>,
+
+    /// 启用AOF（Append Only File）持久化，即所有的写命令都会被记录到一个文件中，true / false
+    #[arg(long)]
+    pub appendonly: Option<String>,
+
+    /// 定义AOF持久化文件的名称
+    #[arg(long)]
+    pub appendfilename: Option<String>,
+
+    #[arg(long)]
+    pub appendfsync: Option<String>,
+
+    ///  log level: OFF, ERROR, WARN, INFO, DEBUG, TRACE
+    #[arg(long, default_value = "info")]
+    pub log_level: log::Level,
+
+    /// 指定配置
+    #[arg(long, value_hint = clap::ValueHint::FilePath)]
+    pub config: Option<PathBuf>,
+}
+
+fn parse_rdb_save(s: &str) -> Result<(u64, u64), Box<dyn Error + Send + Sync + 'static>> {
+    let pos = s
+        .find('/')
+        .ok_or_else(|| format!("invalid M/N : no '/' found in '{s}'"))?;
+    Ok((s[..pos].parse()?, s[pos + 1..].parse()?))
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,3 +1,4 @@
-pub mod pattern;
+pub mod cli;
 pub mod date;
+pub mod pattern;
 pub mod resp;


### PR DESCRIPTION

使用 clap 转换命令行参数，并调换了文件配置与命令行参数的优先级

建议：
1. 修改 `RedisConfig` 参数类型，集中在创建时而非在中途进行格式及类型的转化
2. 使用 [toml](https://docs.rs/toml/latest/toml/) 序列化配置文件，但意味着依赖 [serde](https://serde.rs/)