### PR TITLE
set default bind addr as 0.0.0.0

### DIFF
--- a/src/db/db_config.rs
+++ b/src/db/db_config.rs
@@ -109,7 +109,7 @@ impl From<crate::tools::cli::Cli> for RedisConfig {
 impl Default for RedisConfig {
     fn default() -> Self {
         Self {
-            bind: "127.0.0.1".to_string(),
+            bind: "0.0.0.0".to_string(),
             port: 6379,
             password: None,
             databases: 16,
@@ -141,12 +141,12 @@ fn parse_config_line(line: &str) -> Option<(&str, &str)> {
 fn parse_save(value: &str) -> Option<Vec<(u64, u64)>> {
     let mut vec = Vec::new();
     let parts = value.split_whitespace();
-    for part in parts  {
+    for part in parts {
         if let Some(pos) = part.find('/') {
-            if let (Ok(i),Ok(c)) = (part[..pos].parse(), part[pos + 1..].parse()) {
-                vec.push((i,c));
+            if let (Ok(i), Ok(c)) = (part[..pos].parse(), part[pos + 1..].parse()) {
+                vec.push((i, c));
             }
-        }else {
+        } else {
             return None;
         }
     }


### PR DESCRIPTION
我测试了以下构建 Docker Image，需要在容器中绑定 `0.0.0.0` 才能连通，建议修改其为默认，以便可以直接运行容器。

这是我的测试工程：[DeadPoetSpoon/rudis-docker-test](https://github.com/DeadPoetSpoon/rudis-docker-test)

将在每次 `release` 完成之后，利用 [rust官方镜像](https://github.com/docker-library/docs/tree/master/rust) 编译 `Rudis` ，当前使用的 `tag` 是 `1.80.0-bullseye`

如果这样可行，我将在 `Rudis` 工程根目录创建 `docker` 文件夹与对应文件，并添加 ci 脚本