### PR TITLE
fix: handle RESP frame parsing for pipelined requests

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -94,29 +94,55 @@ impl Frame {
     /**
      * 解析粘连的多个命令帧
      *
+     * 说明：
+     * - 假设传入的 bytes 是完整的数据（通常用于测试或一次性读取的场景）
+     * - 如果最后一部分数据不是一个完整的帧，将会被忽略，而不是强行解析
+     *
      * @param bytes 二进制数据
      */
     pub fn parse_multiple_frames(bytes: &[u8]) -> Result<Vec<Frame>, Error> {
         let mut frames = Vec::new();
         let mut position = 0;
-        
+
         while position < bytes.len() {
-            // 查找下一个完整的命令帧
-            if let Some(frame_end) = Frame::find_frame_end(&bytes[position..]) {
-                let frame_bytes = &bytes[position..position + frame_end];
-                let frame = Frame::parse_from_bytes(frame_bytes)?;
-                frames.push(frame);
-                position += frame_end;
-            } else {
-                // 如果找不到完整的帧结束位置，将剩余的数据作为最后一个帧处理
-                let frame_bytes = &bytes[position..];
-                let frame = Frame::parse_from_bytes(frame_bytes)?;
-                frames.push(frame);
-                break;
+            match Frame::parse_next_frame(&bytes[position..])? {
+                Some((frame, frame_len)) => {
+                    frames.push(frame);
+                    position += frame_len;
+                }
+                None => {
+                    // 没有足够的数据解析出下一个完整帧，直接结束循环
+                    break;
+                }
             }
         }
-        
+
         Ok(frames)
+    }
+
+    /**
+     * 从给定的字节切片中解析出第一个完整的命令帧
+     *
+     * 返回值：
+     * - Ok(Some((frame, used_len)))：成功解析出一个完整帧，其中 used_len 表示该帧占用的字节长度
+     * - Ok(None)：当前字节数据不足以构成一个完整帧，需要继续读取更多数据
+     * - Err(e)：数据格式有问题，无法解析
+     *
+     * @param bytes 二进制数据
+     */
+    pub fn parse_next_frame(bytes: &[u8]) -> Result<Option<(Frame, usize)>, Error> {
+        if bytes.is_empty() {
+            return Ok(None);
+        }
+
+        if let Some(frame_end) = Frame::find_frame_end(bytes) {
+            let frame_bytes = &bytes[..frame_end];
+            let frame = Frame::parse_from_bytes(frame_bytes)?;
+            Ok(Some((frame, frame_end)))
+        } else {
+            // 当前数据还不足以构成一个完整的帧
+            Ok(None)
+        }
     }
     
     /**

--- a/src/server.rs
+++ b/src/server.rs
@@ -269,6 +269,9 @@ impl Handler {
 
     /// Handling client connections
     pub async fn handle(&mut self) {
+        // 为每个连接维护一个读缓冲区，用于处理半包/粘包场景
+        let mut read_buffer: Vec<u8> = Vec::new();
+
         loop {
 
             log::debug!("Waiting for bytes");
@@ -281,21 +284,41 @@ impl Handler {
                     return;
                 }
             };
-            
-            // 解析可能的多个粘连命令帧
-            let frames = match Frame::parse_multiple_frames(bytes.as_slice()) {
-                Ok(frames) => frames,
-                Err(e) => {
-                    log::error!("Failed to parse multiple frames: {:?}", e);
-                    let frame = Frame::Error(format!("Failed to parse frames: {:?}", e));
-                    self.session.connection.write_bytes(frame.as_bytes()).await;
-                    continue;
-                }
-            };
-            
-            log::debug!("Received bytes: {:?}", String::from_utf8_lossy(bytes.as_slice()));
-            
-            for frame in frames {
+
+            // 将本次读取的数据追加到连接缓冲区中
+            read_buffer.extend_from_slice(bytes.as_slice());
+
+            log::debug!(
+                "Received bytes (buffer size {}): {:?}",
+                read_buffer.len(),
+                String::from_utf8_lossy(read_buffer.as_slice())
+            );
+
+            // 尝试从缓冲区中解析尽可能多的完整命令帧
+            loop {
+                let parse_result = Frame::parse_next_frame(read_buffer.as_slice());
+
+                let (frame, used_len) = match parse_result {
+                    Ok(Some((frame, used_len))) => (frame, used_len),
+                    Ok(None) => {
+                        // 当前缓冲区中的数据不足以构成一个完整的帧，等待下一次读取
+                        break;
+                    }
+                    Err(e) => {
+                        // 解析失败，记录错误并向客户端返回错误信息
+                        log::error!("Failed to parse frame from buffer: {:?}", e);
+                        let frame = Frame::Error(format!("Failed to parse frames: {:?}", e));
+                        self.session.connection.write_bytes(frame.as_bytes()).await;
+
+                        // 为避免死循环，丢弃当前缓冲区数据
+                        read_buffer.clear();
+                        break;
+                    }
+                };
+
+                // 从缓冲区移除已经被成功解析的那部分数据
+                read_buffer.drain(0..used_len);
+
                 log::debug!("Received frame: {}", frame.to_string());
                 let frame_copy = frame.clone();
                 if self.session.is_in_transaction() {


### PR DESCRIPTION
- Add incremental frame parser with buffering support
- Maintain per-connection read buffer to handle TCP stick/partial packets
- Avoid parsing incomplete tail data as full frames to prevent Unknown frame type errors from pipelined clients