### PR TITLE
修复aof无法启用的问题

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -376,7 +376,7 @@ impl Command {
             Command::Pfadd(_) |
             Command::Pfmerge(_) |
             Command::Geoadd(_) |
-            Command::GeoaddJson(_) |
+            Command::GeoaddJson(_) => true,
             _ => false,
         }
     }


### PR DESCRIPTION
检测所有的命令都返回false，导致命令无法保存